### PR TITLE
Added code to fetch the shortened URL length from Twitter.

### DIFF
--- a/knowledge_share/twitter_helpers.py
+++ b/knowledge_share/twitter_helpers.py
@@ -80,6 +80,14 @@ def post_microblog_post_on_twitter(microblog_post):
         access_token=settings.TWITTER_ACCESS_TOKEN,
         access_token_secret=settings.TWITTER_ACCESS_TOKEN_SECRET
     )
+
+    try:
+        config_obj = api.configuration().get()
+        current_length = config_obj.get('short_url_length', TWITTER_URL_SHORTENER_SIZE)
+        TWITTER_URL_SHORTENER_SIZE = current_length
+    except ClientError:
+        pass
+
     post_content = format_twitter_post(microblog_post)
     try:
         api.statuses_update().post(params={'status': post_content})


### PR DESCRIPTION
Added code to fetch info from Twitter's configs in order to get the current length of the shortened link, instead of using a hardcoded value. The code falls back to the hardcoded value if something goes wrong, though.

## Motivation and Context
Issue: https://github.com/vintasoftware/django-knowledge-share/issues/11 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
